### PR TITLE
feat(education): add Education Content Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ src/
 │   ├── ai/
 │   ├── auth/
 │   ├── community/
+│   ├── education/
 │   ├── journals/
 │   ├── routine/
 │   └── users/
@@ -150,6 +151,10 @@ Semua endpoint berada di bawah prefix: **`/api/v1`**
 - `POST /community` - Buat postingan baru.
 - `POST /community/:postId/comments` - Tambah komentar ke postingan.
 - `POST /community/:postId/like` - Like postingan.
+
+### Edukasi
+
+- `GET /education` - Ambil semua konten edukasi.
 
 ## 🤝 Kontribusi
 

--- a/src/api/education/education.controller.ts
+++ b/src/api/education/education.controller.ts
@@ -1,0 +1,9 @@
+import type { Request, Response } from 'express';
+import { findAllEducationContents } from './education.service.js';
+import { asyncHandler } from '../../core/asyncHandler.js';
+import { successResponse } from '../../core/response.js';
+
+export const getEducationContentsHandler = asyncHandler(async (req: Request, res: Response) => {
+  const contents = await findAllEducationContents();
+  return successResponse(res, 200, 'Education contents fetched successfully', contents);
+});

--- a/src/api/education/education.routes.ts
+++ b/src/api/education/education.routes.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { getEducationContentsHandler } from './education.controller.js';
+
+const router = Router();
+
+router.get('/', getEducationContentsHandler);
+
+export default router;

--- a/src/api/education/education.service.ts
+++ b/src/api/education/education.service.ts
@@ -1,0 +1,11 @@
+import prisma from '../../database/prisma.js';
+
+export async function findAllEducationContents() {
+  const contents = await prisma.educationContent.findMany({
+    orderBy: {
+      title: 'asc',
+    },
+  });
+
+  return contents;
+}

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -5,6 +5,7 @@ import routineRoutes from '../api/routine/routine.routes.js';
 import journalRoutes from '../api/journals/journal.routes.js';
 import communityRoutes from '../api/community/community.routes.js';
 import aiRoutes from '../api/ai/ai.routes.js';
+import educationRoutes from '../api/education/education.routes.js';
 
 const router = Router();
 
@@ -14,5 +15,6 @@ router.use('/routine', routineRoutes);
 router.use('/journals', journalRoutes);
 router.use('/community', communityRoutes);
 router.use('/ai', aiRoutes);
+router.use('/education', educationRoutes);
 
 export default router;


### PR DESCRIPTION
This PR introduces the **Education** feature, providing structured educational content through a dedicated API endpoint.

### Changes
- **Education Module**
  - Created Education Controller for handling content requests
  - Implemented Education Service to manage business logic
  - Added Education Routes and registered them in the main route index

- **Documentation**
  - Updated `README.md` with a new **Education Section**
  - Added details for the **GET /api/education** endpoint

### Impact
- Backend now supports fetching educational content via API
- Developers can easily expand educational materials in the future
- Documentation is updated for clear reference on the new endpoint