### PR TITLE
feat(db): add Prisma seeders and database seeding documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,26 @@ npm run build
 npm start
 ```
 
+### 🌱 Database Seeding
+
+Proyek ini dilengkapi dengan mekanisme _seeding_ untuk mengisi database dengan data awal untuk keperluan development dan testing.
+
+Data yang di-seed meliputi:
+
+- **Users**: Pengguna dummy
+- **Profiles**: Profil untuk setiap pengguna
+- **Streaks**: Riwayat streak
+- **Check-ins**: Data check-in harian
+- **Journals**: Entri jurnal
+- **Community**: Postingan dan komentar di komunitas
+- **Education**: Konten edukasi
+
+Untuk menjalankan proses seeding, gunakan perintah:
+
+```bash
+npm run db:seed
+```
+
 ## 📜 Skrip NPM
 
 - `npm run dev` - Jalankan server development (hot reload).
@@ -97,6 +117,7 @@ npm start
 - `npm run format` - Format kode dengan Prettier.
 - `npm run db:migrate` - Jalankan migrasi database.
 - `npm run db:studio` - Buka Prisma Studio.
+- `npm run db:seed` - Isi database dengan data awal.
 
 ## 📂 Struktur Proyek
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
+        "@faker-js/faker": "^10.0.0",
         "@google/generative-ai": "^0.24.1",
         "@prisma/client": "^6.15.0",
         "date-fns": "^4.1.0",
@@ -675,6 +676,22 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-10.0.0.tgz",
+      "integrity": "sha512-UollFEUkVXutsaP+Vndjxar40Gs5JL2HeLcl8xO1QAjJgOdhc3OmBFWyEylS+RddWaaBiAzH+5/17PLQJwDiLw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0",
+        "npm": ">=10"
       }
     },
     "node_modules/@google/generative-ai": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "db:deploy": "prisma migrate deploy",
     "db:reset": "prisma migrate reset",
     "db:push": "prisma db push",
-    "db:studio": "prisma studio"
+    "db:studio": "prisma studio",
+    "db:seed": "tsx src/database/seed/index.ts"
   },
   "repository": {
     "type": "git",
@@ -29,6 +30,7 @@
   },
   "homepage": "https://github.com/recova-app/backend#readme",
   "dependencies": {
+    "@faker-js/faker": "^10.0.0",
     "@google/generative-ai": "^0.24.1",
     "@prisma/client": "^6.15.0",
     "date-fns": "^4.1.0",

--- a/src/database/seed/checkin.seed.ts
+++ b/src/database/seed/checkin.seed.ts
@@ -1,0 +1,23 @@
+import prisma from '../prisma.js';
+import { faker } from '@faker-js/faker';
+import { subDays } from 'date-fns';
+
+export async function seedCheckins() {
+  const users = await prisma.user.findMany();
+
+  for (const user of users) {
+    const days = Array.from({ length: 10 }).map((_, i) => subDays(new Date(), i));
+    for (const day of days) {
+      await prisma.checkin.create({
+        data: {
+          checkinDate: day,
+          mood: faker.helpers.arrayElement(['Happy', 'Sad', 'Relaxed', 'Anxious', 'Motivated']),
+          isSuccessful: faker.datatype.boolean(),
+          userId: user.id,
+        },
+      });
+    }
+  }
+
+  console.log(`[database]: Seeded checkins for ${users.length} users`);
+}

--- a/src/database/seed/checkin.seed.ts
+++ b/src/database/seed/checkin.seed.ts
@@ -12,7 +12,7 @@ export async function seedCheckins() {
         data: {
           checkinDate: day,
           mood: faker.helpers.arrayElement(['Happy', 'Sad', 'Relaxed', 'Anxious', 'Motivated']),
-          isSuccessful: faker.datatype.boolean(),
+          isSuccessful: faker.helpers.arrayElement([true, false]),
           userId: user.id,
         },
       });

--- a/src/database/seed/community.seed.ts
+++ b/src/database/seed/community.seed.ts
@@ -1,0 +1,34 @@
+import prisma from '../prisma.js';
+import { faker } from '@faker-js/faker';
+
+export async function seedCommunity() {
+  const users = await prisma.user.findMany();
+
+  for (const user of users) {
+    const postCount = faker.number.int({ min: 2, max: 4 });
+
+    for (let i = 0; i < postCount; i++) {
+      const post = await prisma.communityPost.create({
+        data: {
+          title: faker.lorem.sentence(),
+          content: faker.lorem.paragraph(),
+          userId: user.id,
+        },
+      });
+
+      // Add comments to each post
+      const commentCount = faker.number.int({ min: 1, max: 3 });
+      for (let j = 0; j < commentCount; j++) {
+        await prisma.communityComment.create({
+          data: {
+            content: faker.lorem.sentence(),
+            userId: faker.helpers.arrayElement(users).id,
+            postId: post.id,
+          },
+        });
+      }
+    }
+  }
+
+  console.log(`[database]: Seeded community posts & comments`);
+}

--- a/src/database/seed/education.seed.ts
+++ b/src/database/seed/education.seed.ts
@@ -1,0 +1,24 @@
+import prisma from '../prisma.js';
+import { faker } from '@faker-js/faker';
+
+export async function seedEducationContent() {
+  const contents = Array.from({ length: 10 }).map(() => ({
+    title: faker.lorem.words(4),
+    description: faker.lorem.sentences(2),
+    url: faker.internet.url(),
+    thumbnailUrl: faker.image.urlLoremFlickr({ category: 'education' }),
+    category: faker.helpers.arrayElement([
+      'Mindfulness',
+      'Wellness',
+      'Productivity',
+      'Mental Health',
+      'Self-Improvement',
+    ]),
+  }));
+
+  await prisma.educationContent.createMany({
+    data: contents,
+  });
+
+  console.log('[database]: Seeded education content');
+}

--- a/src/database/seed/index.ts
+++ b/src/database/seed/index.ts
@@ -1,0 +1,32 @@
+import prisma from '../prisma.js';
+import { seedCheckins } from './checkin.seed.js';
+import { seedCommunity } from './community.seed.js';
+import { seedEducationContent } from './education.seed.js';
+import { seedJournals } from './journal.seed.js';
+import { seedProfiles } from './profile.seed.js';
+import { seedStreaks } from './streak.seed.js';
+import { seedUsers } from './user.seed.js';
+
+async function main() {
+  console.log('[database]: Connecting to the database...');
+  await prisma.$connect();
+
+  console.log('[database]: Starting full seeding process...');
+  await seedUsers();
+  await seedProfiles();
+  await seedStreaks();
+  await seedCheckins();
+  await seedJournals();
+  await seedCommunity();
+  await seedEducationContent();
+  console.log('[database]: All seeds completed successfully!');
+}
+
+main()
+  .catch(e => {
+    console.error('[database]: Seed error:', e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/src/database/seed/journal.seed.ts
+++ b/src/database/seed/journal.seed.ts
@@ -1,0 +1,18 @@
+import prisma from '../prisma.js';
+import { faker } from '@faker-js/faker';
+
+export async function seedJournals() {
+  const checkins = await prisma.checkin.findMany();
+
+  for (const checkin of checkins) {
+    await prisma.journal.create({
+      data: {
+        content: faker.lorem.paragraph(),
+        userId: checkin.userId,
+        checkinId: checkin.id,
+      },
+    });
+  }
+
+  console.log(`[database]: Seeded ${checkins.length} journals`);
+}

--- a/src/database/seed/profile.seed.ts
+++ b/src/database/seed/profile.seed.ts
@@ -1,0 +1,23 @@
+import prisma from '../prisma.js';
+import { faker } from '@faker-js/faker';
+
+export async function seedProfiles() {
+  const users = await prisma.user.findMany();
+
+  for (const user of users) {
+    await prisma.userProfile.create({
+      data: {
+        answers: {
+          q1: faker.helpers.arrayElement(['Yes', 'No', 'Sometimes']),
+          q2: faker.helpers.arrayElement(['Often', 'Rarely', 'Never']),
+          q3: faker.helpers.arrayElement(['High', 'Medium', 'Low']),
+        },
+        dependencyLevel: faker.helpers.arrayElement(['Low', 'Medium', 'High']),
+        aiSummary: faker.lorem.sentences(2),
+        userId: user.id,
+      },
+    });
+  }
+
+  console.log(`[database]: Seeded ${users.length} user profiles`);
+}

--- a/src/database/seed/streak.seed.ts
+++ b/src/database/seed/streak.seed.ts
@@ -1,0 +1,27 @@
+import prisma from '../prisma.js';
+import { faker } from '@faker-js/faker';
+import { subDays } from 'date-fns';
+
+export async function seedStreaks() {
+  const users = await prisma.user.findMany();
+
+  for (const user of users) {
+    const totalStreaks = faker.number.int({ min: 1, max: 3 });
+
+    for (let i = 0; i < totalStreaks; i++) {
+      const start = subDays(new Date(), faker.number.int({ min: 10, max: 30 }));
+      await prisma.streak.create({
+        data: {
+          startDate: start,
+          endDate: faker.datatype.boolean()
+            ? subDays(new Date(), faker.number.int({ min: 1, max: 5 }))
+            : null,
+          isActive: faker.datatype.boolean(),
+          userId: user.id,
+        },
+      });
+    }
+  }
+
+  console.log(`[database]: Seeded streaks for ${users.length} users`);
+}

--- a/src/database/seed/streak.seed.ts
+++ b/src/database/seed/streak.seed.ts
@@ -13,10 +13,10 @@ export async function seedStreaks() {
       await prisma.streak.create({
         data: {
           startDate: start,
-          endDate: faker.datatype.boolean()
+          endDate: faker.helpers.arrayElement([true, false])
             ? subDays(new Date(), faker.number.int({ min: 1, max: 5 }))
             : null,
-          isActive: faker.datatype.boolean(),
+          isActive: faker.helpers.arrayElement([true, false]),
           userId: user.id,
         },
       });

--- a/src/database/seed/user.seed.ts
+++ b/src/database/seed/user.seed.ts
@@ -1,0 +1,27 @@
+import prisma from '../prisma.js';
+import { faker } from '@faker-js/faker';
+
+export async function seedUsers() {
+  const usersData = Array.from({ length: 15 }).map(() => ({
+    googleId: faker.string.uuid(),
+    email: faker.internet.email(),
+    nickname: faker.person.firstName(),
+    userWhy: faker.helpers.arrayElement([
+      'To improve mindfulness',
+      'To manage stress',
+      'To achieve better focus',
+      'To sleep better',
+      'To increase productivity',
+      'To build healthy habits',
+      'To reduce anxiety',
+      'To enhance emotional well-being',
+    ]),
+  }));
+
+  const users = await prisma.user.createMany({
+    data: usersData,
+    skipDuplicates: true,
+  });
+
+  console.log(`[database]: Seeded ${users.count} users.`);
+}


### PR DESCRIPTION
This PR introduces **database seeding** using Prisma to populate the database with dummy data for development and testing purposes.

### Changes
- **Database Seeders**
  - Added seed scripts for:
    - Users
    - Profiles
    - Streaks
    - Check-ins
    - Journals
    - Community Posts & Comments
    - Education Content
  - Created centralized `index.ts` to run all seeders
  - Added `db:seed` script to `package.json` for easy execution
  - Installed `fakerjs` for generating realistic dummy data

- **Documentation**
  - Added database seeding guide in `README.md`
  - Explained the purpose of seeding and listed all seeded data
  - Included the command to run the seeding process

### Impact
- Simplifies database setup for new developers
- Provides consistent dummy data for testing and development
- Enhances development workflow with a reproducible seeded dataset