### PR TITLE
fix(build): ensure views are included in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ COPY --from=builder /usr/src/app/node_modules ./node_modules
 COPY --from=builder /usr/src/app/dist ./dist
 COPY --from=builder /usr/src/app/prisma ./prisma
 COPY --from=builder /usr/src/app/node_modules/.prisma ./node_modules/.prisma
+COPY --from=builder /usr/src/app/src/views ./dist/views
 
 EXPOSE 3000
 


### PR DESCRIPTION
This PR merges the `fix/build-views` branch into `dev`, addressing a build issue where the **views directory** was not copied into the final Docker image.

### Changes

* **Dockerfile Update**

  * Added a step to copy the `views` directory from the builder stage into the final image’s `dist` folder
  * Ensures EJS templates are available in production builds

### Impact

* Fixes missing views in production container
* Restores proper rendering for server-side templates
* Improves consistency between local and production environments

### Notes

* No application logic changes
* Safe to merge and deploy immediately