### PR TITLE
feat(user): add endpoint to reset user data for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Semua endpoint berada di bawah prefix: **`/api/v1`**. Pengaturan rute utama terd
 - **`/api/v1/users`**: Rute untuk manajemen profil dan data pengguna.
   - `GET /me` - Ambil detail profil pengguna.
   - `PUT /settings` - Update pengaturan profil.
+  - `DELETE /me/reset-data` - Reset data pengguna untuk testing (hanya untuk development).
 
 - **`/api/v1/ai`**: Rute untuk fitur berbasis AI.
   - `POST /ask-coach` - Kirim pesan ke AI Coach.

--- a/src/api/users/user.controller.ts
+++ b/src/api/users/user.controller.ts
@@ -1,5 +1,5 @@
 import type { Request, Response } from 'express';
-import { findUserById, updateUserSettings } from './user.service.js';
+import { findUserById, resetUserDataForTesting, updateUserSettings } from './user.service.js';
 import { asyncHandler } from '../../handler/async.handler.js';
 import { errorResponse, successResponse } from '../../core/response.js';
 
@@ -42,4 +42,29 @@ export const updateUserSettingsHandler = asyncHandler(async (req: Request, res: 
 
   const updatedUser = await updateUserSettings(userId, dataToUpdate);
   return successResponse(res, 200, 'Pengaturan pengguna berhasil diperbarui', updatedUser);
+});
+
+export const resetUserDataHandler = asyncHandler(async (req: Request, res: Response) => {
+  // Uncomment the following lines if you want to restrict this endpoint to development environment only
+  // if (config.nodeEnv !== 'development') {
+  //   return errorResponse(
+  //     res,
+  //     403,
+  //     'Akses ditolak',
+  //     'Endpoint ini hanya dapat diakses di lingkungan pengembangan'
+  //   );
+  // }
+
+  const userId = req.user?.id;
+  if (!userId) {
+    return errorResponse(
+      res,
+      401,
+      'Tidak diizinkan',
+      'ID pengguna tidak ditemukan dalam permintaan'
+    );
+  }
+
+  const result = await resetUserDataForTesting(userId);
+  return successResponse(res, 200, 'Data pengguna berhasil direset', result);
 });

--- a/src/api/users/user.routes.ts
+++ b/src/api/users/user.routes.ts
@@ -1,5 +1,9 @@
 import { Router } from 'express';
-import { getMeHandler, updateUserSettingsHandler } from './user.controller.js';
+import {
+  getMeHandler,
+  resetUserDataHandler,
+  updateUserSettingsHandler,
+} from './user.controller.js';
 import { requireAuth } from '../../middleware/auth.middleware.js';
 import { validate } from '../../middleware/validate.middleware.js';
 import { updateUserSettingsSchema } from './user.validation.js';
@@ -9,5 +13,7 @@ const router = Router();
 router.get('/me', requireAuth, getMeHandler);
 
 router.put('/settings', requireAuth, validate(updateUserSettingsSchema), updateUserSettingsHandler);
+
+router.delete('/me/reset-data', requireAuth, resetUserDataHandler);
 
 export default router;


### PR DESCRIPTION
### Summary
This pull request introduces a new feature to support easier testing by allowing a user’s data to be reset through an endpoint.

### Changes
- Added new endpoint to reset user data for testing
- Implemented logic to:
  - Delete all comments related to the user's posts
  - Delete all related data for the user
  - Reset `userWhy` and `checkinTime` fields to their default state

### Purpose
This endpoint is mainly for development and testing environments, enabling clean data resets without manual DB operations.