### PR TITLE
feat(routine): add endpoint to retrieve user relapse history

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Semua endpoint berada di bawah prefix: **`/api/v1`**. Pengaturan rute utama terd
 - **`/api/v1/routine`**: Rute untuk rutinitas harian dan statistik.
   - `POST /checkin` - Check-in harian.
   - `GET /statistics` - Statistik (streak, dll).
+  - `GET /relapses` - Ambil riwayat relapse pengguna.
 
 - **`/api/v1/journals`**: Rute untuk jurnal pribadi pengguna.
   - `GET /` - Ambil semua entri jurnal.

--- a/src/api/routine/routine.controller.ts
+++ b/src/api/routine/routine.controller.ts
@@ -1,5 +1,5 @@
 import type { Request, Response } from 'express';
-import { getUserStatistics, processDailyCheckin } from './routine.service.js';
+import { findUserRelapses, getUserStatistics, processDailyCheckin } from './routine.service.js';
 import { asyncHandler } from '../../handler/async.handler.js';
 import { errorResponse, successResponse } from '../../core/response.js';
 
@@ -33,4 +33,19 @@ export const getStatisticsHandler = asyncHandler(async (req: Request, res: Respo
 
   const statistics = await getUserStatistics(userId);
   return successResponse(res, 200, 'Statistik berhasil diambil', statistics);
+});
+
+export const getRelapsesHandler = asyncHandler(async (req: Request, res: Response) => {
+  const userId = req.user?.id || req.body.userId; // Temporary support for userId in body for testing purposes
+  if (!userId) {
+    return errorResponse(
+      res,
+      401,
+      'Tidak diizinkan',
+      'ID pengguna tidak ditemukan dalam permintaan'
+    );
+  }
+
+  const relapses = await findUserRelapses(userId);
+  return successResponse(res, 200, 'Riwayat relapse berhasil diambil', relapses);
 });

--- a/src/api/routine/routine.routes.ts
+++ b/src/api/routine/routine.routes.ts
@@ -1,5 +1,9 @@
 import { Router } from 'express';
-import { dailyCheckinHandler, getStatisticsHandler } from './routine.controller.js';
+import {
+  dailyCheckinHandler,
+  getRelapsesHandler,
+  getStatisticsHandler,
+} from './routine.controller.js';
 import { requireAuth } from '../../middleware/auth.middleware.js';
 import { validate } from '../../middleware/validate.middleware.js';
 import { dailyCheckinSchema } from './routine.validation.js';
@@ -11,5 +15,8 @@ router.post('/checkin', validate(dailyCheckinSchema), dailyCheckinHandler);
 
 // router.get('/statistics', requireAuth, getStatisticsHandler);
 router.get('/statistics', getStatisticsHandler);
+
+// router.get('/relapses', requireAuth, getRelapsesHandler);
+router.get('/relapses', getRelapsesHandler);
 
 export default router;

--- a/src/api/routine/routine.service.ts
+++ b/src/api/routine/routine.service.ts
@@ -132,3 +132,24 @@ export async function getUserStatistics(userId: string) {
     streakCalendar: streakCalendarDates,
   };
 }
+
+export async function findUserRelapses(userId: string) {
+  const relapses = await prisma.checkin.findMany({
+    where: {
+      userId,
+      isSuccessful: false,
+    },
+    orderBy: {
+      createdAt: 'desc',
+    },
+    include: {
+      journal: {
+        select: {
+          content: true,
+        },
+      },
+    },
+  });
+
+  return relapses;
+}


### PR DESCRIPTION
### Summary
This pull request introduces a new API endpoint to retrieve a user's relapse history, providing visibility into their recovery progress.

### Changes
- **Service Layer**
  - Implemented `findUserRelapses` in `routine.service.ts` to fetch relapse records from the database.
- **Controller**
  - Added `getRelapsesHandler` in `routine.controller.ts` to handle incoming requests and return formatted relapse data.
- **Routing**
  - Registered new route `/api/v1/routine/relapses` in `routine.routes.ts`.

### Endpoint
```

GET /api/v1/routine/relapses

```

### Reason
This feature is part of the user progress tracking system — enabling users to review past relapse data for self-reflection and behavioral insight.

### Notes
- Requires user authentication (once middleware is re-enabled)
- Response structure follows the existing routine API schema