### PR TITLE
feat(onboarding): simplify onboarding data structure and integrate AI summary

### DIFF
--- a/prisma/migrations/20251114134933_simplify_schema_for_mvp/migration.sql
+++ b/prisma/migrations/20251114134933_simplify_schema_for_mvp/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."UserProfile" ALTER COLUMN "dependencyLevel" DROP NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -122,7 +122,7 @@ model EducationContent {
 model UserProfile {
   id              String   @id @default(uuid())
   answers         Json
-  dependencyLevel String
+  dependencyLevel String?
   aiSummary       String?
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt

--- a/src/api/auth/auth.controller.ts
+++ b/src/api/auth/auth.controller.ts
@@ -1,5 +1,6 @@
 import type { Request, Response } from 'express';
 import { saveOnboardingData, verifyGoogleTokenAndLogin } from './auth.service.js';
+import { analyzeOnboardingAnswers } from '../ai/ai.service.js';
 import { asyncHandler } from '../../handler/async.handler.js';
 import { errorResponse, successResponse } from '../../core/response.js';
 
@@ -24,6 +25,10 @@ export const onboardingHandler = asyncHandler(async (req: Request, res: Response
   }
 
   const profile = await saveOnboardingData(userId, onboardingData);
+  const aiSummary = await analyzeOnboardingAnswers(onboardingData);
 
-  return successResponse(res, 201, 'Data onboarding berhasil disimpan', profile);
+  return successResponse(res, 201, 'Data onboarding berhasil disimpan', {
+    profile,
+    aiSummary,
+  });
 });

--- a/src/api/auth/auth.controller.ts
+++ b/src/api/auth/auth.controller.ts
@@ -25,10 +25,17 @@ export const onboardingHandler = asyncHandler(async (req: Request, res: Response
   }
 
   const profile = await saveOnboardingData(userId, onboardingData);
-  const aiSummary = await analyzeOnboardingAnswers(onboardingData);
+
+  let aiSummary;
+  try {
+    aiSummary = await analyzeOnboardingAnswers(onboardingData.answers);
+  } catch (error) {
+    console.error('AI summary generation failed:', error);
+    aiSummary = { error: 'AI summary tidak tersedia saat ini' };
+  }
 
   return successResponse(res, 201, 'Data onboarding berhasil disimpan', {
-    profile,
+    ...profile,
     aiSummary,
   });
 });

--- a/src/api/auth/auth.service.ts
+++ b/src/api/auth/auth.service.ts
@@ -50,9 +50,9 @@ export async function saveOnboardingData(
   userId: string,
   data: {
     answers: Record<string, any>;
-    dependencyLevel: string;
+    dependencyLevel?: string;
     userWhy?: string;
-    checkinTime: string;
+    checkinTime?: string;
   }
 ) {
   const { answers, dependencyLevel, userWhy, checkinTime } = data;
@@ -69,12 +69,12 @@ export async function saveOnboardingData(
   const userProfile = await prisma.userProfile.create({
     data: {
       answers,
-      dependencyLevel,
+      dependencyLevel: dependencyLevel || null,
       userId,
     },
   });
 
-  const formattedCheckinTime = parseCheckinTime(checkinTime);
+  const formattedCheckinTime = parseCheckinTime(checkinTime || '09:00');
 
   if (userWhy || formattedCheckinTime) {
     await prisma.user.update({

--- a/src/api/auth/auth.validation.ts
+++ b/src/api/auth/auth.validation.ts
@@ -9,7 +9,12 @@ export const googleLoginSchema = z.object({
 export const onboardingSchema = z.object({
   body: z.object({
     answers: z.record(z.string(), z.unknown()),
-    dependencyLevel: z.string().min(1, 'Tingkat ketergantungan harus diisi').trim(),
+    dependencyLevel: z
+      .string()
+      .min(1, 'Tingkat ketergantungan harus diisi')
+      .trim()
+      .optional()
+      .refine(val => !val || val.length > 0, { message: 'Tingkat ketergantungan harus diisi' }),
     userWhy: z
       .string()
       .optional()
@@ -19,6 +24,10 @@ export const onboardingSchema = z.object({
       .regex(/^([01]\d|2[0-3]):([0-5]\d)$/, {
         message: 'Format waktu check-in tidak valid, gunakan format HH:mm',
       })
-      .trim(),
+      .trim()
+      .optional()
+      .refine(val => !val || /^([01]\d|2[0-3]):([0-5]\d)$/.test(val), {
+        message: 'Format waktu check-in tidak valid, gunakan format HH:mm',
+      }),
   }),
 });

--- a/src/api/auth/auth.validation.ts
+++ b/src/api/auth/auth.validation.ts
@@ -9,12 +9,7 @@ export const googleLoginSchema = z.object({
 export const onboardingSchema = z.object({
   body: z.object({
     answers: z.record(z.string(), z.unknown()),
-    dependencyLevel: z
-      .string()
-      .min(1, 'Tingkat ketergantungan harus diisi')
-      .trim()
-      .optional()
-      .refine(val => !val || val.length > 0, { message: 'Tingkat ketergantungan harus diisi' }),
+    dependencyLevel: z.string().min(1, 'Tingkat ketergantungan harus diisi').trim().optional(),
     userWhy: z
       .string()
       .optional()
@@ -25,9 +20,6 @@ export const onboardingSchema = z.object({
         message: 'Format waktu check-in tidak valid, gunakan format HH:mm',
       })
       .trim()
-      .optional()
-      .refine(val => !val || /^([01]\d|2[0-3]):([0-5]\d)$/.test(val), {
-        message: 'Format waktu check-in tidak valid, gunakan format HH:mm',
-      }),
+      .optional(),
   }),
 });

--- a/src/database/seed/index.ts
+++ b/src/database/seed/index.ts
@@ -15,6 +15,7 @@ async function main() {
 
   console.log('[database]: Resetting existing data...');
   await prisma.communityComment.deleteMany();
+  await prisma.communityPostLike.deleteMany();
   await prisma.communityPost.deleteMany();
   await prisma.journal.deleteMany();
   await prisma.checkin.deleteMany();
@@ -23,6 +24,7 @@ async function main() {
   await prisma.educationContent.deleteMany();
   await prisma.dailyMotivation.deleteMany();
   await prisma.dailyChallenge.deleteMany();
+  await prisma.aiChatHistory.deleteMany();
   await prisma.user.deleteMany();
 
   console.log('[database]: Starting full seeding process...');


### PR DESCRIPTION
### Summary
This pull request streamlines the onboarding process for the MVP by reducing required fields and enhancing the response with AI-generated summaries.

### Changes
- **Validation**
  - Made `dependencyLevel` and `checkinTime` optional in the onboarding validation schema.
- **Database**
  - Updated Prisma schema to allow `dependencyLevel` to be nullable.
  - Reset `aiChatHistory` entries in the seed for clean test data.
- **API Enhancements**
  - Added `aiSummary` to onboarding API responses.
  - Improved onboarding flow to integrate summary generation cleanly.

### Reason
This simplification reduces friction during onboarding and ensures the MVP demo runs smoothly with fewer required inputs. AI summary integration also boosts user experience by providing immediate contextual insights.

### Notes
- Requires Prisma schema update (`npx prisma migrate dev`)
- AI summary generation uses existing AI config—no breaking changes
- Old onboarding data should be checked for compatibility